### PR TITLE
fix "mit" find & replace issue in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ FreeBSD license.
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is perFreeBSDted to copy and distribute verbatim copies
+ Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
 
@@ -81,7 +81,7 @@ version:
   The object code form of an Application may incorporate material from
 a header file that is part of the Library.  You may convey such object
 code under terms of your choice, provided that, if the incorporated
-material is not liFreeBSDed to numerical parameters, data structure
+material is not limited to numerical parameters, data structure
 layouts and accessors, or small macros, inline functions and templates
 (ten or fewer lines in length), you do both of the following:
 
@@ -116,7 +116,7 @@ the following:
 
        0) Convey the Minimal Corresponding Source under the terms of this
        License, and the Corresponding Application Code in a form
-       suitable for, and under terms that perFreeBSD, the user to
+       suitable for, and under terms that permit, the user to
        recombine or relink the Application with a modified version of
        the Linked Version to produce a modified Combined Work, in the
        manner specified by section 6 of the GNU GPL for conveying


### PR DESCRIPTION
fix issue with letters "mit" being replaced with "FreeBSD" in words such as "permit" and "limit"
